### PR TITLE
fix: handle Next.js 15+ redirect errors properly

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -240,6 +240,17 @@ export async function GET(request: Request) {
     const destination = authState.redirect_uri || ROUTES.USER;
     return redirect(destination);
   } catch (error) {
+    // Next.js redirect() throws a NEXT_REDIRECT error that must be re-thrown
+    if (
+      error &&
+      typeof error === 'object' &&
+      'digest' in error &&
+      typeof error.digest === 'string' &&
+      error.digest.startsWith('NEXT_REDIRECT')
+    ) {
+      throw error;
+    }
+
     // Log error for debugging
     console.error('Error in callback handler:', error);
 

--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -24,15 +24,18 @@ import { ROUTES } from '@/lib/oidc/constants';
  * redirect('/auth/error?code=access_denied&description=User denied access');
  * ```
  */
-export default function AuthErrorPage({
+export default async function AuthErrorPage({
   searchParams,
 }: {
-  searchParams: { code?: string; error?: string; description?: string; error_uri?: string };
+  searchParams: Promise<{ code?: string; error?: string; description?: string; error_uri?: string }>;
 }) {
+  // In Next.js 15+, searchParams is a Promise that must be awaited
+  const params = await searchParams;
+
   // Get error code from query params (prefer 'code', fallback to 'error')
-  const errorCode = searchParams.code || searchParams.error || 'unknown_error';
-  const errorDescription = searchParams.description || 'An unknown error occurred.';
-  const errorUri = searchParams.error_uri;
+  const errorCode = params.code || params.error || 'unknown_error';
+  const errorDescription = params.description || 'An unknown error occurred.';
+  const errorUri = params.error_uri;
 
   // Format the error for display
   const error = formatErrorForDisplay(errorCode, errorDescription);

--- a/src/app/auth/login/route.ts
+++ b/src/app/auth/login/route.ts
@@ -135,6 +135,17 @@ export async function GET(request: Request) {
     // Redirect to provider's authorization endpoint
     return redirect(authorizationUrl);
   } catch (error) {
+    // Next.js redirect() throws a NEXT_REDIRECT error that must be re-thrown
+    if (
+      error &&
+      typeof error === 'object' &&
+      'digest' in error &&
+      typeof error.digest === 'string' &&
+      error.digest.startsWith('NEXT_REDIRECT')
+    ) {
+      throw error;
+    }
+
     // Log error and redirect to error page
     console.error('Error initiating authorization flow:', error);
 


### PR DESCRIPTION
In Next.js 15+, the redirect() function throws a NEXT_REDIRECT error that must be re-thrown to perform the redirect. The try-catch blocks were incorrectly treating these as errors.

Also fixed searchParams to be awaited as it's now a Promise in Next.js 15+.